### PR TITLE
Fix race when recreating toolchain.

### DIFF
--- a/opentoolchain/resource_opentoolchain_pipeline_properties.go
+++ b/opentoolchain/resource_opentoolchain_pipeline_properties.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	oc "github.com/dariusbakunas/opentoolchain-go-sdk/opentoolchainv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -69,8 +70,11 @@ func resourceOpenToolchainPipelineProperties() *schema.Resource {
 func resourceOpenToolchainPipelinePropertiesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	guid := d.Get("guid").(string)
-	envID := d.Get("env_id").(string)
+	id := d.Id()
+	idParts := strings.Split(id, "/")
+
+	guid := idParts[0]
+	envID := idParts[1]
 
 	config := m.(*ProviderConfig)
 	c := config.OTClient

--- a/opentoolchain/resource_opentoolchain_pipeline_properties.go
+++ b/opentoolchain/resource_opentoolchain_pipeline_properties.go
@@ -22,11 +22,13 @@ func resourceOpenToolchainPipelineProperties() *schema.Resource {
 			"guid": {
 				Description: "The tekton pipeline `guid`",
 				Type:        schema.TypeString,
+				ForceNew:    true,
 				Required:    true,
 			},
 			"env_id": {
 				Description: "Environment ID, example: `ibm:yp:us-south`",
 				Type:        schema.TypeString,
+				ForceNew:    true,
 				Required:    true,
 			},
 			"name": {
@@ -68,11 +70,8 @@ func resourceOpenToolchainPipelineProperties() *schema.Resource {
 func resourceOpenToolchainPipelinePropertiesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	id := d.Id()
-	idParts := strings.Split(id, "/")
-
-	guid := idParts[0]
-	envID := idParts[1]
+	guid := d.Get("guid").(string)
+	envID := d.Get("env_id").(string)
 
 	config := m.(*ProviderConfig)
 	c := config.OTClient

--- a/opentoolchain/resource_opentoolchain_pipeline_properties.go
+++ b/opentoolchain/resource_opentoolchain_pipeline_properties.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 
 	oc "github.com/dariusbakunas/opentoolchain-go-sdk/opentoolchainv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -151,16 +150,16 @@ func resourceOpenToolchainPipelinePropertiesCreate(ctx context.Context, d *schem
 	secretEnv, secOk := d.GetOk("secret_env")
 
 	if txtOk || secOk {
-        patchOptions.EnvProperties = makeEnvPatch(currentEnv, textEnv, secretEnv)
+		patchOptions.EnvProperties = makeEnvPatch(currentEnv, textEnv, secretEnv)
 
-        // log.Printf("[DEBUG] Patching tekton pipeline: %v", dbgPrint(patchOptions))
+		// log.Printf("[DEBUG] Patching tekton pipeline: %v", dbgPrint(patchOptions))
 
-        _, _, err = c.PatchTektonPipelineWithContext(ctx, patchOptions)
+		_, _, err = c.PatchTektonPipelineWithContext(ctx, patchOptions)
 
-        if err != nil {
-            return diag.Errorf("Failed patching tekton pipeline: %s", err)
-        }
-    }
+		if err != nil {
+			return diag.Errorf("Failed patching tekton pipeline: %s", err)
+		}
+	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *pipeline.ID, envID))
 
@@ -252,7 +251,7 @@ func makeEnvPatch(currentEnv []oc.EnvProperty, textEnv interface{}, secretEnv in
 		}
 	}
 
-    var res []oc.EnvProperty
+	var res []oc.EnvProperty
 
 	for _, v := range envMap {
 		res = append(res, v)


### PR DESCRIPTION
- Force recreate of pipeline overrides when GUID of pipeline changes.
- Formatting changes and removal of unused imports.

When the toolchain is tainted and recreated, the original pipeline is destroyed so the refresh fails when it tries to update
and the whole plan fails. Repeated plan attempts continue to fail because it tried to lookup the old pipeline using the ID
of the resource. Simplest solution was to use ForceNew when the GUID changes, and that seems to work.

